### PR TITLE
Fix user guide, API response, add persistence test

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -128,7 +128,7 @@ def advance_round(game_id):
             # Save updated game state
             game_state_manager.save_game_state(game_state)
             
-            return jsonify({"success": True, "round": game_state.current_round})
+            return jsonify({"success": True, "current_round": game_state.current_round})
         else:
             return jsonify({"error": "Game already finished"}), 400
     except Exception as e:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,27 @@
+import unittest
+import tempfile
+from src.models.game_state import GameState
+from src.models.persistence import GamePersistence
+
+class PersistenceTestCase(unittest.TestCase):
+    def test_save_and_load_game_state(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            persistence = GamePersistence(tmpdir)
+            game_state = GameState(num_teams=2, num_rounds=3)
+            game_state.initialize_game()
+            game_id = game_state.game_id
+            saved = persistence.save_game(
+                game_id,
+                game_state.to_dict(),
+                admin_code=game_state.admin_code,
+                team_codes=game_state.team_codes,
+            )
+            self.assertTrue(saved)
+            loaded_state = persistence.load_game(game_id)
+            self.assertIsNotNone(loaded_state)
+            self.assertEqual(loaded_state["game_id"], game_id)
+            self.assertEqual(loaded_state["num_teams"], 2)
+            self.assertEqual(loaded_state["num_rounds"], 3)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/user_guide.md
+++ b/user_guide.md
@@ -19,8 +19,8 @@ The simulation supports up to 5 competing teams and runs for 10 rounds, with eac
 
 1. **Installation**:
    - Ensure you have Python 3.8+ installed
-   - Install required packages: `pip install flask`
-   - Navigate to the application directory: `cd strategy_game/app`
+   - Install required packages: `pip install -r requirements.txt`
+   - Navigate to the application directory: `cd src`
    - Start the server: `python main.py`
    - Access the application at: `http://localhost:5000`
 


### PR DESCRIPTION
## Summary
- correct installation instructions and server path
- return `current_round` field from advance round endpoint
- test persistence save/load behavior

## Testing
- `python -m unittest discover -v`
