### PR TITLE
Fix requirements formatting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
-Flask==2.2.3\ngunicorn==20.1.0\nWerkzeug==2.2.3\nJinja2==3.1.2\nitsdangerous==2.1.2\nMarkupSafe==2.1.2\npython-dotenv==1.0.0
+Flask==2.2.3
+gunicorn==20.1.0
+Werkzeug==2.2.3
+Jinja2==3.1.2
+itsdangerous==2.1.2
+MarkupSafe==2.1.2
+python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- fix the formatting of `requirements.txt` so each dependency is on its own line

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip install -r requirements.txt` *(fails: No route to host)*